### PR TITLE
Ignore .vs and Emacs temp files

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,1 +1,3 @@
 node_modules/
+.vs/
+*~


### PR DESCRIPTION
`.vs` generated by Visual Studio. `*~` is from Emacs.